### PR TITLE
Bump akka.version in /scala-gradle-maven-docker-starter

### DIFF
--- a/scala-gradle-maven-docker-starter/pom.xml
+++ b/scala-gradle-maven-docker-starter/pom.xml
@@ -15,7 +15,7 @@
     <encoding>UTF-8</encoding>
     <scala.compat.version>2.11</scala.compat.version>
     <scala.version>${scala.compat.version}.8</scala.version>
-    <akka.version>2.5.9</akka.version>
+    <akka.version>2.5.31</akka.version>
     <scalatestic.version>3.0.4</scalatestic.version>
     <lombok.version>1.16.18</lombok.version>
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Bumps `akka.version` from 2.5.9 to 2.5.31.

Updates `akka-actor_2.11` from 2.5.9 to 2.5.31
- [Release notes](https://github.com/akka/akka/releases)
- [Commits](https://github.com/akka/akka/compare/v2.5.9...v2.5.31)

Updates `akka-slf4j_2.11` from 2.5.9 to 2.5.31
- [Release notes](https://github.com/akka/akka/releases)
- [Commits](https://github.com/akka/akka/compare/v2.5.9...v2.5.31)

Updates `akka-stream_2.11` from 2.5.9 to 2.5.31
- [Release notes](https://github.com/akka/akka/releases)
- [Commits](https://github.com/akka/akka/compare/v2.5.9...v2.5.31)

Updates `akka-cluster_2.11` from 2.5.9 to 2.5.31
- [Release notes](https://github.com/akka/akka/releases)
- [Commits](https://github.com/akka/akka/compare/v2.5.9...v2.5.31)

Updates `akka-persistence_2.11` from 2.5.9 to 2.5.31
- [Release notes](https://github.com/akka/akka/releases)
- [Commits](https://github.com/akka/akka/compare/v2.5.9...v2.5.31)

Updates `akka-testkit_2.11` from 2.5.9 to 2.5.31
- [Release notes](https://github.com/akka/akka/releases)
- [Commits](https://github.com/akka/akka/compare/v2.5.9...v2.5.31)

Updates `akka-stream-testkit_2.11` from 2.5.9 to 2.5.31
- [Release notes](https://github.com/akka/akka/releases)
- [Commits](https://github.com/akka/akka/compare/v2.5.9...v2.5.31)

Signed-off-by: dependabot[bot] <support@github.com>